### PR TITLE
#36 - 해시태그 검색 및 조회 페이지 구현

### DIFF
--- a/board/src/main/java/com/spring/board/controller/ArticleController.java
+++ b/board/src/main/java/com/spring/board/controller/ArticleController.java
@@ -61,4 +61,22 @@ public class ArticleController {
         return "articles/detail";
     }
 
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(size = 10, sort = "createdAt",direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ) {
+        var articles= articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        var barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
+    }
+
 }

--- a/board/src/main/java/com/spring/board/repository/ArticleRepository.java
+++ b/board/src/main/java/com/spring/board/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.spring.board.domain.Article;
 import com.spring.board.domain.QArticle;
+import com.spring.board.repository.querydsl.ArticleRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom, // Querydsl 설정
         QuerydslPredicateExecutor<Article>, // Querydsl 설정 + 기본 검색 기능 추가
         QuerydslBinderCustomizer<QArticle> {
 

--- a/board/src/main/java/com/spring/board/repository/querydsl/ArticleRepositoryCustom.java
+++ b/board/src/main/java/com/spring/board/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.spring.board.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+
+    List<String> findAllDistinctHashtags();
+}

--- a/board/src/main/java/com/spring/board/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/board/src/main/java/com/spring/board/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,25 @@
+package com.spring.board.repository.querydsl;
+
+import com.spring.board.domain.Article;
+import com.spring.board.domain.QArticle;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+        return from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull())
+                .fetch();
+
+    }
+}

--- a/board/src/main/java/com/spring/board/service/ArticleService.java
+++ b/board/src/main/java/com/spring/board/service/ArticleService.java
@@ -18,6 +18,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional
@@ -78,5 +79,19 @@ public class ArticleService {
 
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        if (!StringUtils.hasText(hashtag)) {
+            return Page.empty(pageable);
+        }
+        return articleRepository
+                .findByHashtag(hashtag, pageable)
+                .map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtags();
     }
 }

--- a/board/src/main/resources/templates/articles/search-hashtag.html
+++ b/board/src/main/resources/templates/articles/search-hashtag.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
+    <title>해시태그 검색</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
+</head>
+
+<body>
+<header id="header">
+    헤더 삽입부
+    <hr>
+</header>
+
+<main class="container">
+    <header class="py-5 text-center">
+        <h1>Hashtags</h1>
+    </header>
+
+    <section class="row">
+        <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+            <div class="p-2">
+                <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+            </div>
+        </div>
+    </section>
+
+    <hr>
+
+    <table class="table" id="article-table">
+        <thead>
+        <tr>
+            <th class="title col-6"><a>제목</a></th>
+            <th class="content col-4"><a>본문</a></th>
+            <th class="user-id"><a>작성자</a></th>
+            <th class="created-at"><a>작성일</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="title"><a>첫글</a></td>
+            <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+            <td class="user-id">Uno</td>
+            <td class="created-at"><time>2022-01-01</time></td>
+        </tr>
+        <tr>
+            <td>두번째글</td>
+            <td>본문</td>
+            <td>Uno</td>
+            <td><time>2022-01-02</time></td>
+        </tr>
+        <tr>
+            <td>세번째글</td>
+            <td>본문</td>
+            <td>Uno</td>
+            <td><time>2022-01-03</time></td>
+        </tr>
+        </tbody>
+    </table>
+
+    <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="#">1</a></li>
+            <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+    </nav>
+
+</main>
+
+<footer id="footer">
+    <hr>
+    푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/board/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/board/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
+
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+            page=${param.page},
+            sort=${param.sort},
+            searchType=${searchType.name},
+            searchValue=${hashtag}
+        )}" />
+            </attr>
+        </attr>
+
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.content/a" th:text="'본문'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+            </attr>
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.content/span" th:text="${article.content}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:text="'previous'"
+                      th:href="@{/articles(page=${articles.number - 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                    <attr sel="a"
+                          th:text="${pageNumber + 1}"
+                          th:href="@{/articles(page=${pageNumber}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                          th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                    />
+                </attr>
+                <attr sel="li[2]/a"
+                      th:text="'next'"
+                      th:href="@{/articles(page=${articles.number + 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+                />
+            </attr>
+        </attr>
+    </attr>
+</thlogic>

--- a/board/src/test/java/com/spring/board/controller/ArticleControllerTest.java
+++ b/board/src/test/java/com/spring/board/controller/ArticleControllerTest.java
@@ -2,6 +2,7 @@ package com.spring.board.controller;
 
 import com.spring.board.config.SecurityConfig;
 import com.spring.board.domain.constant.SearchType;
+import com.spring.board.dto.ArticleDto;
 import com.spring.board.dto.ArticleWithCommentsDto;
 import com.spring.board.dto.UserAccountDto;
 import com.spring.board.service.ArticleService;
@@ -120,22 +121,72 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-//    @DisplayName("[view] [GET] 게시글 상세 페이지 - 정상 호출 ")
-//    @Test
-//    public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
-//        // given
-//        Long articleId = 1L;
-//        given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentDto());
-//
-//        // when & then
-//        mvc.perform(get("/articles/" + articleId))
-//                .andExpect(status().isOk())
-//                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-//                .andExpect(view().name("articles/detail"))
-//                .andExpect(model().attributeExists("article"))
-//                .andExpect(model().attributeExists("articleComments"));
-//        then(articleService).should().getArticle(articleId);
-//    }
+    @DisplayName("[view] [GET] 게시글 상세 페이지 - 정상 호출 ")
+    @Test
+    public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
+        // given
+        Long articleId = 1L;
+        given(articleService.getArticle(articleId)).willReturn(createArticleDto());
+
+        // when & then
+        mvc.perform(get("/articles/" + articleId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/detail"))
+                .andExpect(model().attributeExists("article"))
+                .andExpect(model().attributeExists("articleComments"));
+        then(articleService).should().getArticle(articleId);
+    }
+
+    @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingArticleSearchHashtagView_thenReturnsArticleSearchHashtagView() throws Exception {
+        // Given
+        List<String> hashtags = List.of("#java", "#spring", "#boot");
+        given(articleService.searchArticlesViaHashtag(eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(articleService.getHashtags()).willReturn(hashtags);
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(1, 2, 3, 4, 5));
+
+        // When & Then
+        mvc.perform(get("/articles/search-hashtag"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/search-hashtag"))
+                .andExpect(model().attribute("articles", Page.empty()))
+                .andExpect(model().attribute("hashtags", hashtags))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attribute("searchType", SearchType.HASHTAG));
+        then(articleService).should().searchArticlesViaHashtag(eq(null), any(Pageable.class));
+        then(articleService).should().getHashtags();
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출, 해시태그 입력")
+    @Test
+    void givenHashtag_whenRequestingArticleSearchHashtagView_thenReturnsArticleSearchHashtagView() throws Exception {
+        // Given
+        String hashtag = "#java";
+        List<String> hashtags = List.of("#java", "#spring", "#boot");
+        given(articleService.searchArticlesViaHashtag(eq(hashtag), any(Pageable.class))).willReturn(Page.empty());
+        given(articleService.getHashtags()).willReturn(hashtags);
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(1, 2, 3, 4, 5));
+
+        // When & Then
+        mvc.perform(
+                        get("/articles/search-hashtag")
+                                .queryParam("searchValue", hashtag)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/search-hashtag"))
+                .andExpect(model().attribute("articles", Page.empty()))
+                .andExpect(model().attribute("hashtags", hashtags))
+                .andExpect(model().attributeExists("paginationBarNumbers"))
+                .andExpect(model().attribute("searchType", SearchType.HASHTAG));
+        then(articleService).should().searchArticlesViaHashtag(eq(hashtag), any(Pageable.class));
+        then(articleService).should().getHashtags();
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
 
     @Disabled("구현 중")
     @DisplayName("[view] [GET] 게시글 검색 전용 페이지 - 정상 호출 ")
@@ -149,6 +200,7 @@ class ArticleControllerTest {
                 .andExpect(view().name("articles/search"))
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
     }
+
 
     @Disabled("구현 중")
     @DisplayName("[view] [GET] 게시글 해시태그 검색 페이지 - 정상 호출 ")
@@ -175,6 +227,20 @@ class ArticleControllerTest {
                 LocalDateTime.now(),
                 "woo",
                 Set.of()
+        );
+    }
+
+    private ArticleDto createArticleDto() {
+        return ArticleDto.of(
+                1L,
+                createUserAccountDto(),
+                "title",
+                "content",
+                "#java",
+                LocalDateTime.now(),
+                "woo",
+                LocalDateTime.now(),
+                "woo"
         );
     }
 

--- a/board/src/test/java/com/spring/board/service/ArticleServiceTest.java
+++ b/board/src/test/java/com/spring/board/service/ArticleServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -168,6 +169,24 @@ class ArticleServiceTest {
 //        then(articleRepository).should().getReferenceById(articleId);
 //        then(articleRepository).should().flush();
     }
+
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsHashtags() {
+        // Given
+        Article article = createArticle();
+        List<String> expectedHashtags = List.of("java", "spring", "boot");
+        given(articleRepository.findAllDistinctHashtags()).willReturn(expectedHashtags);
+
+        // When
+        List<String> actualHashtags = sut.getHashtags();
+
+        // Then
+        assertThat(actualHashtags).isEqualTo(expectedHashtags);
+        then(articleRepository).should().findAllDistinctHashtags();
+    }
+
+
 
     public UserAccount createUserAccount() {
         return UserAccount.of(


### PR DESCRIPTION
 * 해시태그 리스트 조회 및 클릭시 게시글 조회 링크 기능
 * 전체 해시태그 리스트 제공
 * 해시태그 클릭시 해당 게시글 제공
 * Querydsl 사용